### PR TITLE
Replaced missing formatDate function

### DIFF
--- a/fullAlbumDate/fullAlbumDate.js
+++ b/fullAlbumDate/fullAlbumDate.js
@@ -10,7 +10,7 @@
     async function getAlbumDate(uri) {
         const albumInfo = await CosmosAsync.get(`https://api.spotify.com/v1/albums/${uri}`);
         const albumDate = new Date(albumInfo.release_date);
-        return Locale.formatDate(albumDate);
+        return Locale.formatRelativeTime( albumDate );
     }
 
     function replaceDate(newDate) {


### PR DESCRIPTION
Replaced the call to `Locale.formatDate` since (afaik) there is no such function in the `Spicetify.Locale` module anymore.

This formats the date like so: "November 22, 2009".

No idea if that's the preferred method to use, but I kept seeing the same errors every time I went to an album page so I tossed this in and it works for me.

