### PR TITLE
[listPlaylistsWithSong] should now include glitched collab playlist

### DIFF
--- a/listPlaylistsWithSong/listPlaylistsWithSong.js
+++ b/listPlaylistsWithSong/listPlaylistsWithSong.js
@@ -40,7 +40,7 @@
                         uri: playlist.uri,
                         title: playlist.name,
                         desc: playlist.description,
-                        isCollab: playlist.isCollaborative,
+                        isCollab: playlist.isCollaborative || playlist.canAdd,
                         noOfSongs: playlist.totalLength,
                         created: playlist.addedAt.toLocaleString("default", { year: "numeric", month: "short", day: "numeric" }),
                         image: image,
@@ -58,7 +58,7 @@
         const userContents = await Spicetify.Platform.RootlistAPI.getContents();
         for (const playlist of userContents.items) {
             if (playlist.type == "playlist") {
-                if ((playlist.isCollaborative || playlist.isOwnedBySelf) && playlist.totalLength > 0) {
+                if ((playlist.isCollaborative || playlist.isOwnedBySelf || playlist.canAdd) && playlist.totalLength > 0) {
                     let image;
                     try {
                         image = !playlist.images[0]
@@ -71,7 +71,7 @@
                         uri: playlist.uri,
                         title: playlist.name,
                         desc: playlist.description,
-                        isCollab: playlist.isCollaborative,
+                        isCollab: playlist.isCollaborative || playlist.canAdd,
                         noOfSongs: playlist.totalLength,
                         created: playlist.addedAt.toLocaleString("default", { year: "numeric", month: "short", day: "numeric" }),
                         image: image,

--- a/listPlaylistsWithSong/listPlaylistsWithSong.js
+++ b/listPlaylistsWithSong/listPlaylistsWithSong.js
@@ -27,7 +27,7 @@
         let playlists = [];
         for (const playlist of folder) {
             if (playlist.type == "playlist") {
-                if ((playlist.isCollaborative || playlist.isOwnedBySelf) && playlist.totalLength > 0) {
+                if ((playlist.isCollaborative || playlist.isOwnedBySelf || playlist.canAdd) && playlist.totalLength > 0) {
                     let image;
                     try {
                         image = !playlist.images[0]


### PR DESCRIPTION
Bugged playlists:
https://open.spotify.com/playlist/499E9KTm9avwUkLlD6cqRI
https://open.spotify.com/playlist/1hTCnxm27ofzacxjn8P5wf
![image](https://github.com/huhridge/huh-spicetify-extensions/assets/156434647/d3d2fadc-7fad-4e02-be00-16f2f5bdb372)

While ``.canAdd`` fixes this and is tested in my extension, I did not test it in yours, but I don't see a reason why it shouldn't work.