### PR TITLE
fix(FAD): fix fetchColors

### DIFF
--- a/fullAppDisplayModified/fullAppDisplayMod.js
+++ b/fullAppDisplayModified/fullAppDisplayMod.js
@@ -489,7 +489,7 @@ body.video-full-screen.video-full-screen--hide-ui {
         let colors = {};
 
         try {
-            const body = await Spicetify.CosmosAsync.get(`wg://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
+            const body = await Spicetify.CosmosAsync.get(`https://spclient.wg.spotify.com/colorextractor/v1/extract-presets?uri=${uri}&format=json`);
             for (const color of body.entries[0].color_swatches) {
                 colors[color.preset] = `#${color.color.toString(16).padStart(6, "0")}`;
             }


### PR DESCRIPTION
fixes #88, #101

The colors are always black because the `wg://` protocol doesn't seem to work
![image](https://github.com/user-attachments/assets/710a2064-9b00-41b5-9e1e-db84702a29b2)

Changed the url from `wg://` to `spclient.wg.spotify.com`, which is [what `Spicetify.colorextractor` is using.](https://github.com/spicetify/cli/blob/bb767a9059143fe183c1c577acff335dc6a462b7/jsHelper/spicetifyWrapper.js#L1046)

Note that one of the 6 colors returned missing the `preset` key, which should probably be the `PROMINENT` color.
Currently the code doesn't handle the color and just set it to the `undefined` key.
![image](https://github.com/user-attachments/assets/6424f899-bcaa-4cbd-bb7d-2a93a818ad20)
